### PR TITLE
Feature/add pdf to a recognition

### DIFF
--- a/config/cl-authorization/config.lisp
+++ b/config/cl-authorization/config.lisp
@@ -48,7 +48,8 @@
   :foaf "http://xmlns.com/foaf/0.1/"
   :m8g "http://data.europa.eu/m8g/"
   :org "http://www.w3.org/ns/org#"
-  :organisatie "http://lblod.data.gift/vocabularies/organisatie/")
+  :organisatie "http://lblod.data.gift/vocabularies/organisatie/"
+  :nfo "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#")
 
 ;;;;;;;;;;;;;;;;;
 ;; access queries
@@ -83,6 +84,7 @@
 (define-graph verenigingen-loket ("http://mu.semte.ch/graphs/organizations/")
   ;; This is scoped by session_group and role when suppling access rights
   ;; TODO: should this be scoped only on session_group?
+  ("nfo:FileDataObject" -> _)
   ("adres:Postinfo" -> _)
   ("feitelijkeverenigingen:Erkenning" -> _)
   ("m8g:PeriodOfTime" -> _)
@@ -91,6 +93,7 @@
   ("org:Organization" -> _))
 
 (define-graph organization ("http://mu.semte.ch/graphs/organizations/")
+  ("nfo:FileDataObject" -> _)
   ("foaf:Person" -> _)
   ("foaf:OnlineAccount" -> _)
   ("adms:Identifier" -> _))

--- a/config/dispatcher/dispatcher-controle.ex
+++ b/config/dispatcher/dispatcher-controle.ex
@@ -15,6 +15,22 @@ defmodule Dispatcher do
   @json %{ accept: %{ json: true } }
   @html %{ accept: %{ html: true } }
 
+  post "/files/*path" do
+    Proxy.forward conn, path, "http://file/files/"
+  end
+
+  get "/files/:id/download", %{ layer: :api } do
+    Proxy.forward conn, [], "http://file/files/" <> id <> "/download"
+  end
+
+  delete "/files/*path", %{ accept: [ :json ], layer: :api } do
+    Proxy.forward conn, path, "http://file/files/"
+  end
+
+  get "/files/*path", %{layer: :api, accept: %{any: true}} do
+    Proxy.forward(conn, path, "http://resource/files/")
+  end
+
   match "/organizations/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/organizations/"
   end

--- a/config/dispatcher/dispatcher-controle.ex
+++ b/config/dispatcher/dispatcher-controle.ex
@@ -27,7 +27,7 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://file/files/"
   end
 
-  get "/files/*path", %{layer: :api, accept: %{any: true}} do
+  get "/files/*path", %{layer: :api, accept: [ :json ]} do
     Proxy.forward(conn, path, "http://resource/files/")
   end
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -18,6 +18,22 @@ defmodule Dispatcher do
 
 
 
+  post "/files/*path" do
+    Proxy.forward conn, path, "http://file/files/"
+  end
+
+  get "/files/:id/download", %{ layer: :api } do
+    Proxy.forward conn, [], "http://file/files/" <> id <> "/download"
+  end
+
+  delete "/files/*path", %{ accept: [ :json ], layer: :api } do
+    Proxy.forward conn, path, "http://file/files/"
+  end
+
+  get "/files/*path", %{layer: :api, accept: %{any: true}} do
+    Proxy.forward(conn, path, "http://resource/files/")
+  end
+
   match "/organizations/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/organizations/"
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -30,7 +30,7 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://file/files/"
   end
 
-  get "/files/*path", %{layer: :api, accept: %{any: true}} do
+  get "/files/*path", %{layer: :api, accept: [ :json ]} do
     Proxy.forward(conn, path, "http://resource/files/")
   end
 

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -1,6 +1,9 @@
 {
   "version": "0.1",
   "prefixes": {
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "nie": "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#",
+    "resource": "http://dbpedia.org/resource/",
     "org": "http://www.w3.org/ns/org#",
     "locn": "http://www.w3.org/ns/locn#",
     "bestuurcode": "http://lblod.data.gift/vocabularies/organisatie/",
@@ -39,6 +42,44 @@
     "eli": "http://data.europa.eu/eli/ontology#"
   },
   "resources": {
+    "files": {
+      "name": "file",
+      "class": "nfo:FileDataObject",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "nfo:fileName"
+        },
+        "format": {
+          "type": "string",
+          "predicate": "dct:format"
+        },
+        "size": {
+          "type": "integer",
+          "predicate": "nfo:fileSize"
+        },
+        "extension": {
+          "type": "string",
+          "predicate": "resource:fileExtension"
+        },
+        "created": {
+          "type": "datetime",
+          "predicate": "dct:created"
+        }
+      },
+      "relationships": {
+        "download": {
+          "predicate": "nie:dataSource",
+          "target": "file",
+          "cardinality": "one",
+          "inverse": true
+        }
+      },
+      "new-resource-base": "http://data.lblod.info/files/",
+      "features": [
+        "include-uri"
+      ]
+    },
     "addresses": {
       "name": "address",
       "class": "locn:Address",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,8 @@ services:
     restart: always
   file:
     image: semtech/mu-file-service:3.4.0
+    environment:
+      MU_APPLICATION_FILE_STORAGE_PATH: recognitions
     links:
       - database:database
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,3 +189,9 @@ services:
     environment:
       - discovery.type=single-node
     restart: always
+  file:
+    image: semtech/mu-file-service:3.4.0
+    links:
+      - database:database
+    volumes:
+      - ./data/files:/share


### PR DESCRIPTION
CLBV-282

As a user, I want to add a PDF file of a recognition decision manually.

Steps
User clicks on Add file.
Platform opens local file overview.
User selects PDF-file.
Platform saves file (the same implementation as in Loket Lokale Besturen)
Platform returns to Edit recognition page.
User clicks on 'Save'.

Exceptions

User adds any other file than a PDF-file
Platform shows error message ‘Enkel een PDF-bestand is toegelaten.’
User adds a PDF-file.

User clicks on 'x' next file.
Platform deletes file.
User can add a link.

User clicks on 'Cancel'.
Platform closes Edit recognition page.
Platform return to Recognitions overview page.

Link is already present in entry field.
User clicks on Add file - by adding a file the url is replaced by file name.

Result

User adds a PDF-file.