### PR TITLE
[CLBV-891]: change verenigingen datatype

### DIFF
--- a/config/cl-authorization/config.lisp
+++ b/config/cl-authorization/config.lisp
@@ -88,7 +88,7 @@
   ("adres:Postinfo" -> _)
   ("feitelijkeverenigingen:Erkenning" -> _)
   ("m8g:PeriodOfTime" -> _)
-  ("feitelijkeverenigingen:FeitelijkeVereniging" -> _)
+  ("feitelijkeverenigingen:Vereniging" -> _)
   ("besluit:Bestuurseenheid" -> _)
   ("org:Organization" -> _))
 

--- a/config/consumer/harvester/query/association.js
+++ b/config/consumer/harvester/query/association.js
@@ -1,6 +1,6 @@
 const ASSOCIATION_QUERY = `INSERT {
   GRAPH ?g {
-    ?association a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#FeitelijkeVereniging> ;
+    ?association a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging> ;
                  mu:uuid ?Auuid ;
                  skos:prefLabel ?alabel ;
                  dcterms:description ?adescription ;

--- a/config/consumer/harvester/query/contactpoint.js
+++ b/config/consumer/harvester/query/contactpoint.js
@@ -1,6 +1,6 @@
 const CONTACTPOINT_QUERY = `INSERT {
   GRAPH ?g {
-    ?association a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#FeitelijkeVereniging> .
+    ?association a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging> .
     ?association schema:contactPoint ?contactPointPhone .
     ?contactPointPhone a schema:ContactPoint ;
                        mu:uuid ?contactPointPhoneUuid ;

--- a/config/consumer/harvester/query/membership.js
+++ b/config/consumer/harvester/query/membership.js
@@ -1,6 +1,6 @@
 const MEMBERSHIP_QUERY = `INSERT {
   GRAPH ?g {
-    ?association a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#FeitelijkeVereniging> ;
+    ?association a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging> ;
                  org:hasMembership ?membership .
     ?membership a org:Membership ;
                 mu:uuid ?membershipUuid ;

--- a/config/consumer/harvester/query/site.js
+++ b/config/consumer/harvester/query/site.js
@@ -1,6 +1,6 @@
 const SITE_QUERY = `INSERT {
   GRAPH ?g {
-    ?association a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#FeitelijkeVereniging> ;
+    ?association a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging> ;
                  org:hasSite ?site ;
                  org:hasPrimarySite ?primarySite .
     ?primarySite a org:Site ;

--- a/config/consumer/op/util.js
+++ b/config/consumer/op/util.js
@@ -339,7 +339,7 @@ async function moveToOrgGraph(muUpdate, endpoint){
                 adres:postnaam ?name .
 
         ?association
-                a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#FeitelijkeVereniging>  ;
+                a <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging>  ;
                 ?x ?y ;
                 org:hasPrimarySite ?primarySite .
 

--- a/config/migrations/20240925103520-update-verenigingen-type.sparql
+++ b/config/migrations/20240925103520-update-verenigingen-type.sparql
@@ -1,0 +1,17 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+DELETE {
+  GRAPH ?g {
+    ?association rdf:type <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#FeitelijkeVereniging> .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?association rdf:type <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?association rdf:type <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#FeitelijkeVereniging> .
+  }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -258,7 +258,7 @@
     },
     "associations": {
       "name": "association",
-      "class": "vereniging:FeitelijkeVereniging",
+      "class": "vereniging:Vereniging",
       "super": [
         "organization"
       ],

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -12018,7 +12018,7 @@
         {
             "type": "association",
             "on_path": "associations",
-            "rdf_type": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#FeitelijkeVereniging",
+            "rdf_type": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging",
             "properties": {
                 "type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
                 "name": "http://www.w3.org/2004/02/skos/core#prefLabel",


### PR DESCRIPTION
## ID
CLBV-891

## Description

Use the `https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging` instead of the `https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#FeitelijkeVereniging` datatype

Todo:
- some other services still use the previous datatype, update all of these? https://github.com/search?q=org%3Alblod+https%3A%2F%2Fdata.vlaanderen.be%2Fns%2FFeitelijkeVerenigingen%23FeitelijkeVereniging+NOT+repo%3Alblod%2Fapp-verenigingen-loket+NOT+repo%3Alblod%2Fcycling-request-group-10-service&type=code

## How to test

1. Use dev/qa data locally
2. run the PR
3. The existing datatypes should now be converted with the migration, to check run:
```
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX fv: <https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#>

SELECT (COUNT(?association) AS ?count) ?type ?graph
WHERE {
  GRAPH ?graph {
    ?association rdf:type ?type .
    FILTER(?type IN (fv:FeitelijkeVereniging, fv:Vereniging))
  }
}
GROUP BY ?type ?graph
ORDER BY ?graph ?type

```
4. Verify in the frontend if the verenigingen still work

## Links to other PR's

- http://github.com/PR/2314135
