### PR TITLE
Change scope spreadsheet feature: one file for all

### DIFF
--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -66,6 +66,10 @@
         "created": {
           "type": "datetime",
           "predicate": "dct:created"
+        },
+        "subject": {
+          "type": "url",
+          "predicate": "dct:subject"
         }
       },
       "relationships": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,11 @@ services:
     labels:
       - "logging=true"
   download:
-    image: lblod/verenigingsloket-download-service:1.1.1
+    image: lblod/verenigingsloket-download-service:2.0.0-rc.1
+    environment:
+      CRON_PATTERN_SPREADSHEET_JOB: "0 0 * * *"
+    volumes:
+      - ./data/files:/share
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
We revisited the scope of the dump download. Now a periodic job runs once a day to created the same spreadsheet for everyone.  No ad hoc spreadsheet possible.
See: https://binnenland.atlassian.net/browse/CLBV-954

Testing:
 - clone the branch
 -  `drc up -d`
-  if you want to speed up the cronjob: set the variable to: `CRON_PATTERN_SPREADSHEET_JOB: "* * * * *"`
-  you will need the adapted frontend: https://github.com/lblod/frontend-verenigingen-loket/pull/79