### PR TITLE
Reformat dispatcher config

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -152,11 +152,6 @@ defmodule Dispatcher do
   #   FRONTEND
   ###############################################################
 
-
-  match "/assets/*path", %{ layer: :api } do
-    Proxy.forward conn, path, "http://frontend/assets/"
-  end
-
   match "/assets/*path", %{ layer: :api } do
     Proxy.forward conn, path, "http://frontend/assets/"
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -15,9 +15,6 @@ defmodule Dispatcher do
   @json %{ accept: %{ json: true } }
   @html %{ accept: %{ html: true } }
 
-
-
-
   post "/files/*path" do
     Proxy.forward conn, path, "http://file/files/"
   end
@@ -175,10 +172,6 @@ defmodule Dispatcher do
   match "/groups/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://resource/administrative-units/"
   end
-
-
-
-
 
   match "/*_", %{accept: [:any], layer: :not_found} do
     send_resp( conn, 404, "Route not found.  See config/dispatcher.ex" )

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -135,6 +135,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://login/sessions/"
   end
 
+  match "/groups/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://resource/administrative-units/"
+  end
+
   ###############################################################
   # SEARCH
   ###############################################################
@@ -167,10 +171,6 @@ defmodule Dispatcher do
 
   match "/*_path", %{ layer: :frontend } do
     Proxy.forward conn, [], "http://frontend/index.html"
-  end
-
-  match "/groups/*path", %{ accept: [:json], layer: :api} do
-    Proxy.forward conn, path, "http://resource/administrative-units/"
   end
 
   match "/*_", %{accept: [:any], layer: :not_found} do

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -95,10 +95,6 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/governing-bodies/"
   end
 
-  match "/mock/sessions/*path", %{ accept: [:any], layer: :api} do
-    Proxy.forward conn, path, "http://mocklogin/sessions/"
-  end
-
   match "/users/*path" do
     Proxy.forward conn, path, "http://cache/users/"
   end
@@ -129,6 +125,10 @@ defmodule Dispatcher do
 
   match "/postal-codes/*path", %{ accept: [:any], layer: :api} do
     Proxy.forward conn, path, "http://cache/postal-codes/"
+  end
+
+  match "/mock/sessions/*path", %{ accept: [:any], layer: :api} do
+    Proxy.forward conn, path, "http://mocklogin/sessions/"
   end
 
   match "/sessions/*path" do


### PR DESCRIPTION
**[CLBV-973]**

There is a mismatch between what's in the `dispatcher.ex` and the `dispatcher-controle.ex` on production. After inspecting the differences, I noticed missing entries in the controle config, but also some anomalies in the regular config. This PR would help clarify this. The aim is to have a clear `diff` between the two configs, so that the controle config is easier to maintain.

The changes here just move some rules up or down, remove whitespace and remove duplicates. Check the individual commits to follow every change in atomic form.