### PR TITLE
set max_result_window to 50k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- Allow displaying associations in the overview beyon 10k
+- Allow displaying associations in the overview beyond 10k
   - See also [CLBV-1021]
 
 ### Deploy Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,24 @@
 # Changelog
+
+## unreleased
+
+- Allow displaying associations in the overview beyon 10k
+  - See also [CLBV-1021]
+
+### Deploy Notes
+
+Only needed to update the settings for existing indexes. Newly created indexes will have the new settings by default.
+
+```
+bash scripts/increase-max-result-window.sh
+```
+
 ## 1.5.2 (2025-04-18)
+
 - bump frontend [v1.4.3]
+
 ## 1.5.1 (2025-04-17)
+
 - bump frontend [v1.4.2](https://github.com/lblod/frontend-verenigingen-loket/blob/master/CHANGELOG.md#v140-2025-04-17)
 
 ### Deploy Notes
@@ -11,8 +28,9 @@ drc up -d frontend
 ```
 
 ## 1.5.0 (2025-04-17)
+
 - Fix bug related to duplicate values of some strings.
-  The consumer on initial sync wasn't properly handling multi-line strings. 
+  The consumer on initial sync wasn't properly handling multi-line strings.
   See [PR:delta-consumer](https://github.com/lblod/delta-consumer/pull/36)
   Bug reported [CLBV-1004]. Implies full flush.
 - Update of the data type: https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging
@@ -22,12 +40,17 @@ drc up -d frontend
 - bump verenigingsloket-download-service [v2.1.0](https://github.com/lblod/verenigingsloket-download-service/releases/tag/v2.1.0)
 
 ### Deploy
+
 ### Deploy Notes
+
 Ensure backup first!
+
 ```
 drc down
 ```
+
 Ensure `docker-compose.override.yml` contains:
+
 ```
   harvester-consumer:
     environment:
@@ -36,16 +59,20 @@ Ensure `docker-compose.override.yml` contains:
       DCR_DISABLE_DELTA_INGEST: "true"
       DCR_DISABLE_INITIAL_SYNC: "true"
 ```
+
 ```
 drc up -d migrations
 drc up -d database harvester-consumer
 drc up -d
 ```
+
 Wait for the consumer to finish.
 If that looks okay; reset elastic.
+
 ```
 /bin/bash ./scripts/reset-elastic.sh
 ```
+
 Experienced readers might have noticed that we don't revert the consumer back to ingesting in the `database` to trigger constant updates of `mu-search` and other caches. There is a good reason for that: currently, we are facing a bug in both `mu-auth` and `sparql-parser` that occurs with strings exceeding the ASCII range.
 
 So, we'll have to temporarily revert to ingesting directly in Virtuoso and use a cron job running in the background. After everything is set up correctly, add a cron job on the server using `crontab -e`. Don't forget to update the paths depending on the environment you are in. Also respect the quircks of the cronfile.
@@ -53,13 +80,16 @@ So, we'll have to temporarily revert to ingesting directly in Virtuoso and use a
 ```
 00 4 * * * cd /data/app-verenigingen-loket; ./scripts/reset-elastic.sh > /data/app-verenigingen-loket/reset-elastic.log 2>&1
 ```
+
 That should be it.
 
 # 1.4.0 (2025-03-07)
+
 - Add missing key to `harvester-consumer`. [DL-6490]
 - Reorganize delta consumers config to harmonize with the ecosystem
 
 ### Deploy Notes
+
 ```
 drc up -d harvester-consumer op-consumer
 ```
@@ -74,63 +104,87 @@ drc up -d harvester-consumer op-consumer
 - CLBV-970: Fix an issue with file downloads in Chrome
 
 ## 1.3.2 (2025-02-17)
+
 ### General
+
 - https://github.com/lblod/app-verenigingen-loket/pull/32
+
 ## 1.3.1 (2025-02-13)
+
 ## Frontend
+
 - CLBV-965: Fix an issue with file downloads in Firefox
 
 ## 1.3.0 (2025-02-12)
+
 ### general
+
 Lots of fixes:
+
 - CLBV-797: postcode filter
 - CLBV-957: change the way data is loaded for activities
 - CLBV-951: change governing body on save erkenning
 - CLBV-954: Download spreadsheet functionality
 - CLBV-958: Improved fuzzy search
 - CLBV-959: fix herstel filter
+
 ### frontend
-  - update excel download
-  - [v1.2.10](https://github.com/lblod/frontend-verenigingen-loket/blob/d3337b4a3aaf414517115b1e3508a34e51e8f240/CHANGELOG.md#v1210-2025-02-10)
-  - [v1.2.9](https://github.com/lblod/frontend-verenigingen-loket/blob/a5d9cadb85f647f533153f9a57f1ae5f906a0a6e/CHANGELOG.md#v129-2025-02-06)
-  - [v1.2.8](https://github.com/lblod/frontend-verenigingen-loket/blob/082687017de29713bb58ae9f73c5d964c11a61c1/CHANGELOG.md#v128-2025-02-06)
+
+- update excel download
+- [v1.2.10](https://github.com/lblod/frontend-verenigingen-loket/blob/d3337b4a3aaf414517115b1e3508a34e51e8f240/CHANGELOG.md#v1210-2025-02-10)
+- [v1.2.9](https://github.com/lblod/frontend-verenigingen-loket/blob/a5d9cadb85f647f533153f9a57f1ae5f906a0a6e/CHANGELOG.md#v129-2025-02-06)
+- [v1.2.8](https://github.com/lblod/frontend-verenigingen-loket/blob/082687017de29713bb58ae9f73c5d964c11a61c1/CHANGELOG.md#v128-2025-02-06)
 
 ### Deploy instructions
+
 ```
 drc down;
 drc up -d
 ```
 
 ## 1.2.1 (2025-01-28)
+
 - multiple updates/clean ups
+
 ### Deploy instructions
+
 #### production
+
 ```
 drc down;
 drc up -d --remove-orphans
 ```
+
 #### development/local
+
 ```
 git fetch origin
 git reset --hard origin/development
 ```
 
 ## 1.2.0 (2025-01-28)
+
 ### Changes
- - Lots of mini bugfixes.
- - Ensure now only one graph, making accessible all verenigingen for all bestuurseenheden.
+
+- Lots of mini bugfixes.
+- Ensure now only one graph, making accessible all verenigingen for all bestuurseenheden.
+
 ### Deploy instructions
+
 ```
 drc down
 rm -rf data
 drc up -d migrations # wait for successs
 ```
+
 On production only update `docker-compose.override.yml` to:
+
 ```
   virtuoso:
     volumes:
       - ./config/virtuoso/virtuoso-production.ini:/data/virtuoso.ini
 ```
+
 (Consider doing the same on QA if it helps)
 
 Then start ingesting `OP` master data.
@@ -146,7 +200,9 @@ Update `docker-compose.override.yml` to:
       DCR_DISABLE_DELTA_INGEST: "false"
       DCR_DISABLE_INITIAL_SYNC: "false"
 ```
+
 Then:
+
 ```
 drc up -d database op-consumer
 # Wait until success of the previous step
@@ -155,7 +211,9 @@ drc up -d update-bestuurseenheid-mock-login
 drc exec update-bestuurseenheid-mock-login curl -X POST http://localhost/heal-mock-logins
 # Takes about 20 min with prod data
 ```
+
 Then, update `docker-compose.override.yml` to:
+
 ```
   op-consumer:
     environment:
@@ -165,12 +223,15 @@ Then, update `docker-compose.override.yml` to:
       DCR_DISABLE_DELTA_INGEST: "false"
       DCR_DISABLE_INITIAL_SYNC: "false"
 ```
+
 ```
 drc up -d op-consumer
 ```
+
 Then update the `verenigen-harvester` master data
 
 Update `docker-compose.override.yml` to:
+
 ```
   harvester-consumer:
     environment:
@@ -188,7 +249,9 @@ Update `docker-compose.override.yml` to:
 ```
 drc up -d database harvester-consumer # wait until this message: delta-sync-queue: Remaining number of tasks 0
 ```
+
 Update `docker-compose.override.yml` to:
+
 ```
   harvester-consumer:
     environment:
@@ -206,17 +269,23 @@ Update `docker-compose.override.yml` to:
 ```
 drc up -d
 ```
+
 Then kick the `mu-search` to do its thing:
+
 ```
 /bin/bash ./scripts/reset-elastic.sh
 ```
+
 ## 1.1.2 (2024-10-24)
+
 - [#19](https://github.com/lblod/app-verenigingen-loket/pull/19) [CLBV-930] Fix zwijndrecht's name ([@wolfderechter](https://github.com/wolfderechter))
 - [#16](https://github.com/lblod/app-verenigingen-loket/pull/16) [CLBV-914] Updated postalcodes ([@wolfderechter](https://github.com/wolfderechter))
 - frontend [v1.2.1](https://github.com/lblod/frontend-verenigingen-loket/blob/master/CHANGELOG.md#v121-2024-10-07)
 
 ## 1.1.1 (2024-08-12)
+
 - Add query retry to consumers and add missing logging [#18](https://github.com/lblod/app-verenigingen-loket/pull/18)
 
 ## 1.1.0 (2024-08-12)
+
 - frontend [v1.1.0](https://github.com/lblod/frontend-verenigingen-loket/blob/master/CHANGELOG.md#v110-2024-08-06)

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -1,290 +1,283 @@
 {
-    "automatic_index_updates": true,
-    "persist_indexes": true,
-    "update_wait_interval_minutes": 1,
-    "number_of_threads": 8,
-    "ignored_allowed_groups": [{ "name": "org", "variables": ["*"] }],
-    "eager_indexing_groups": [
-        [
-            {
-                "variables": [],
-                "name": "public"
-            }
-        ],
-
-        [
-            {
-                "variables": [],
-                "name": "public"
-            },
-            {
-                "variables": [],
-                "name": "verenigingen-lezer"
-            }
-        ],
-        [
-            {
-                "variables": [],
-                "name": "public"
-            },
-            {
-                "variables": [],
-                "name": "verenigingen-beheerder"
-            }
-        ]
+  "automatic_index_updates": true,
+  "persist_indexes": true,
+  "update_wait_interval_minutes": 1,
+  "number_of_threads": 8,
+  "ignored_allowed_groups": [{ "name": "org", "variables": ["*"] }],
+  "eager_indexing_groups": [
+    [
+      {
+        "variables": [],
+        "name": "public"
+      }
     ],
-    "default_settings": {
-        "analysis": {
-            "normalizer": {
-                "custom_sort_normalizer": {
-                    "type": "custom",
-                    "char_filter": [],
-                    "filter": [
-                        "lowercase",
-                        "trim",
-                        "asciifolding"
-                    ]
-                },
-                "identifier_normalizer": {
-                    "type": "custom",
-                    "char_filter": [
-                        "identifier_alphanumeric_filter"
-                    ],
-                    "filter": [
-                        "lowercase",
-                        "trim",
-                        "asciifolding"
-                    ]
-                }
-            },
-            "char_filter": {
-                "identifier_alphanumeric_filter": {
-                    "type": "pattern_replace",
-                    "pattern": "[^a-zA-Z0-9]",
-                    "replacement": ""
-                }
-            }
-        }
-    },
-    "types": [
-        {
-            "type": "association",
-            "on_path": "associations",
-            "rdf_type": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging",
-            "properties": {
-                "type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-                "name": "http://www.w3.org/2004/02/skos/core#prefLabel",
-                "description": "http://www.w3.org/2004/02/skos/core#notation",
-                "lastUpdated": "http://purl.org/pav/lastUpdateOn",
-                "createdOn": "http://purl.org/pav/createdOn",
-                "status": [
-                  "http://www.w3.org/ns/regorg#orgStatus",
-                  "http://www.w3.org/2004/02/skos/core#prefLabel"
-                ],
-                "status_id": [
-                  "http://www.w3.org/ns/regorg#orgStatus",
-                  "http://mu.semte.ch/vocabularies/core/uuid"
-                ],
-                "primarySite": {
-                    "via": "http://www.w3.org/ns/org#hasPrimarySite",
-                    "rdf_type": "http://www.w3.org/ns/org#Site",
-                    "properties": {
-                        "description": "http://purl.org/dc/terms/description",
-                        "address": {
-                            "via": "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
-                            "rdf_type": "http://www.w3.org/ns/locn#Address",
-                            "properties": {
-                                "huisnummer": "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer",
-                                "busnummer": "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer",
-                                "thoroughfare": "http://www.w3.org/ns/locn#thoroughfare",
-                                "postcode": "http://www.w3.org/ns/locn#postCode",
-                                "municipality": "http://www.w3.org/ns/locn#municipality",
-                                "province": "http://www.w3.org/ns/locn#province",
-                                "land": "http://www.w3.org/ns/locn#land",
-                                "gemeentenaam": "http://www.w3.org/ns/locn#gemeentenaam",
-                                "adminUnitL2": "http://www.w3.org/ns/locn#adminUnitL2",
-                                "fullAddress": "http://www.w3.org/ns/locn#fullAddress",
-                                "verwijstNaar": "https://data.vlaanderen.be/ns/adres#verwijstNaar"
-                            }
-                        }
-                    }
-                },
-                "sites": {
-                    "via": "http://www.w3.org/ns/org#hasSite",
-                    "rdf_type": "http://www.w3.org/ns/org#Site",
-                    "properties": {
-                        "description": "http://purl.org/dc/terms/description",
-                        "address": {
-                            "via": "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
-                            "rdf_type": "http://www.w3.org/ns/locn#Address",
-                            "properties": {
-                                "huisnummer": "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer",
-                                "busnummer": "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer",
-                                "thoroughfare": "http://www.w3.org/ns/locn#thoroughfare",
-                                "postcode": "http://www.w3.org/ns/locn#postCode",
-                                "municipality": "http://www.w3.org/ns/locn#municipality",
-                                "province": "http://www.w3.org/ns/locn#province",
-                                "land": "http://www.w3.org/ns/locn#land",
-                                "gemeentenaam": "http://www.w3.org/ns/locn#gemeentenaam",
-                                "adminUnitL2": "http://www.w3.org/ns/locn#adminUnitL2",
-                                "fullAddress": "http://www.w3.org/ns/locn#fullAddress",
-                                "verwijstNaar": "https://data.vlaanderen.be/ns/adres#verwijstNaar"
-                            }
-                        }
-                    }
-                },
-                "activities": {
-                    "via": "http://www.w3.org/ns/regorg#orgActivity",
-                    "rdf_type": "http://www.w3.org/2004/02/skos/core#Concept",
-                    "properties": {
-                        "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
-                        "notation": "http://www.w3.org/2004/02/skos/core#notation",
-                        "conceptScheme": "http://www.w3.org/2004/02/skos/core#inScheme",
-                        "top-concept-of": "http://www.w3.org/2004/02/skos/core#hasTopConcept"
-                    }
-                },
-                "identifiers": {
-                    "via": "http://www.w3.org/ns/adms#identifier",
-                    "rdf_type": "http://www.w3.org/ns/adms#Identifier",
-                    "properties": {
-                        "idName": "http://www.w3.org/2004/02/skos/core#notation",
-                        "structuredIdentifier": {
-                            "via": "https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator",
-                            "rdf_type": "https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator",
-                            "properties": {
-                                "localId": "https://data.vlaanderen.be/ns/generiek#lokaleIdentificator"
-                            }
-                        }
-                    }
-                },
-                "targetAudience": {
-                    "via": "http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/doelgroep",
-                    "rdf_type": "http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/Doelgroep",
-                    "properties": {
-                        "minimumLeeftijd": "http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/minimumleeftijd",
-                        "maximumLeeftijd": "http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/maximumleeftijd"
-                    }
-                },
-                "recognitions": {
-                    "via": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#heeftErkenning",
-                    "rdf_type": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Erkenning",
-                    "properties": {
-                        "status": "http://www.w3.org/ns/adms#status",
-                        "dateDocument": "http://data.europa.eu/eli/ontology#dateDocument",
-                        "legalResource": "http://data.europa.eu/eli/ontology#hasLegalResource",
-                        "validityPeriod": {
-                            "via": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#geldigheidsperiode",
-                            "rdf_type": "http://data.europa.eu/m8g/PeriodOfTime",
-                            "properties": {
-                                "startTime": "http://data.europa.eu/m8g/startTime",
-                                "endTime": "http://data.europa.eu/m8g/endTime"
-                            }
-                        },
-                        "awardedBy": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#toegekendDoor",
-                        "association": "^https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#heeftErkenning"
-                    }
-                },
-                "classification": {
-                    "via": "http://www.w3.org/ns/org#classification",
-                    "rdf_type": "http://www.w3.org/2004/02/skos/core#Concept",
-                    "properties": {
-                        "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
-                        "notation": "http://www.w3.org/2004/02/skos/core#notation",
-                        "modified": "http://purl.org/dc/terms/modified",
-                        "conceptScheme": "http://www.w3.org/2004/02/skos/core#inScheme",
-                        "broader": "http://www.w3.org/2004/02/skos/core#broader",
-                        "top-concept-of": "http://www.w3.org/2004/02/skos/core#hasTopConcept"
-                    }
-                }
-            },
-            "mappings": {
-                "properties": {
-                    "recognitions.validityPeriod.startTime": {
-                        "type": "date"
-                    },
-                    "recognitions.validityPeriod.endTime": {
-                        "type": "date"
-                    },
-                    "name": {
-                        "type": "text",
-                        "fields": {
-                            "field": {
-                                "type": "keyword",
-                                "normalizer": "custom_sort_normalizer"
-                            }
-                        }
-                    },
-                    "date": {
-                        "type": "date"
-                    },
-                    "createdOn": {
-                        "type": "text",
-                        "fields": {
-                            "field": {
-                                "type": "keyword",
-                                "normalizer": "custom_sort_normalizer"
-                            }
-                        }
-                    },
-                    "lastUpdateOn": {
-                        "type": "text",
-                        "fields": {
-                            "field": {
-                                "type": "keyword",
-                                "normalizer": "custom_sort_normalizer"
-                            }
-                        }
-                    },
-                    "primarySite.address.postcode": {
-                        "type": "text",
-                        "fields": {
-                            "field": {
-                                "type": "keyword",
-                                "normalizer": "custom_sort_normalizer"
-                            }
-                        }
-                    },
-                    "identifiers.structuredIdentifier.localId": {
-                        "type": "text",
-                        "fields": {
-                            "field": {
-                                "type": "keyword",
-                                "normalizer": "custom_sort_normalizer"
-                            }
-                        }
-                    },
-                    "status": {
-                      "type": "text",
-                      "fields": {
-                        "field": {
-                          "type": "keyword",
-                          "normalizer": "custom_sort_normalizer"
-                        }
-                      }
-                    },
-                    "status_id": {
-                      "type": "text"
-                    },
-                    "targetAudience.minimumLeeftijd": {
-                        "type": "text",
-                        "fields": {
-                            "field": {
-                                "type": "keyword",
-                                "normalizer": "custom_sort_normalizer"
-                            }
-                        }
-                    },
-                    "targetAudience.maximumLeeftijd": {
-                        "type": "text",
-                        "fields": {
-                            "field": {
-                                "type": "keyword",
-                                "normalizer": "custom_sort_normalizer"
-                            }
-                        }
-                    }
-                }
-            }
-        }
+
+    [
+      {
+        "variables": [],
+        "name": "public"
+      },
+      {
+        "variables": [],
+        "name": "verenigingen-lezer"
+      }
+    ],
+    [
+      {
+        "variables": [],
+        "name": "public"
+      },
+      {
+        "variables": [],
+        "name": "verenigingen-beheerder"
+      }
     ]
+  ],
+  "default_settings": {
+    "index": {
+      "max_result_window": 50000
+    },
+    "analysis": {
+      "normalizer": {
+        "custom_sort_normalizer": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": ["lowercase", "trim", "asciifolding"]
+        },
+        "identifier_normalizer": {
+          "type": "custom",
+          "char_filter": ["identifier_alphanumeric_filter"],
+          "filter": ["lowercase", "trim", "asciifolding"]
+        }
+      },
+      "char_filter": {
+        "identifier_alphanumeric_filter": {
+          "type": "pattern_replace",
+          "pattern": "[^a-zA-Z0-9]",
+          "replacement": ""
+        }
+      }
+    }
+  },
+  "types": [
+    {
+      "type": "association",
+      "on_path": "associations",
+      "rdf_type": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging",
+      "properties": {
+        "type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "name": "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "description": "http://www.w3.org/2004/02/skos/core#notation",
+        "lastUpdated": "http://purl.org/pav/lastUpdateOn",
+        "createdOn": "http://purl.org/pav/createdOn",
+        "status": [
+          "http://www.w3.org/ns/regorg#orgStatus",
+          "http://www.w3.org/2004/02/skos/core#prefLabel"
+        ],
+        "status_id": [
+          "http://www.w3.org/ns/regorg#orgStatus",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
+        "primarySite": {
+          "via": "http://www.w3.org/ns/org#hasPrimarySite",
+          "rdf_type": "http://www.w3.org/ns/org#Site",
+          "properties": {
+            "description": "http://purl.org/dc/terms/description",
+            "address": {
+              "via": "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
+              "rdf_type": "http://www.w3.org/ns/locn#Address",
+              "properties": {
+                "huisnummer": "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer",
+                "busnummer": "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer",
+                "thoroughfare": "http://www.w3.org/ns/locn#thoroughfare",
+                "postcode": "http://www.w3.org/ns/locn#postCode",
+                "municipality": "http://www.w3.org/ns/locn#municipality",
+                "province": "http://www.w3.org/ns/locn#province",
+                "land": "http://www.w3.org/ns/locn#land",
+                "gemeentenaam": "http://www.w3.org/ns/locn#gemeentenaam",
+                "adminUnitL2": "http://www.w3.org/ns/locn#adminUnitL2",
+                "fullAddress": "http://www.w3.org/ns/locn#fullAddress",
+                "verwijstNaar": "https://data.vlaanderen.be/ns/adres#verwijstNaar"
+              }
+            }
+          }
+        },
+        "sites": {
+          "via": "http://www.w3.org/ns/org#hasSite",
+          "rdf_type": "http://www.w3.org/ns/org#Site",
+          "properties": {
+            "description": "http://purl.org/dc/terms/description",
+            "address": {
+              "via": "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
+              "rdf_type": "http://www.w3.org/ns/locn#Address",
+              "properties": {
+                "huisnummer": "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer",
+                "busnummer": "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer",
+                "thoroughfare": "http://www.w3.org/ns/locn#thoroughfare",
+                "postcode": "http://www.w3.org/ns/locn#postCode",
+                "municipality": "http://www.w3.org/ns/locn#municipality",
+                "province": "http://www.w3.org/ns/locn#province",
+                "land": "http://www.w3.org/ns/locn#land",
+                "gemeentenaam": "http://www.w3.org/ns/locn#gemeentenaam",
+                "adminUnitL2": "http://www.w3.org/ns/locn#adminUnitL2",
+                "fullAddress": "http://www.w3.org/ns/locn#fullAddress",
+                "verwijstNaar": "https://data.vlaanderen.be/ns/adres#verwijstNaar"
+              }
+            }
+          }
+        },
+        "activities": {
+          "via": "http://www.w3.org/ns/regorg#orgActivity",
+          "rdf_type": "http://www.w3.org/2004/02/skos/core#Concept",
+          "properties": {
+            "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
+            "notation": "http://www.w3.org/2004/02/skos/core#notation",
+            "conceptScheme": "http://www.w3.org/2004/02/skos/core#inScheme",
+            "top-concept-of": "http://www.w3.org/2004/02/skos/core#hasTopConcept"
+          }
+        },
+        "identifiers": {
+          "via": "http://www.w3.org/ns/adms#identifier",
+          "rdf_type": "http://www.w3.org/ns/adms#Identifier",
+          "properties": {
+            "idName": "http://www.w3.org/2004/02/skos/core#notation",
+            "structuredIdentifier": {
+              "via": "https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator",
+              "rdf_type": "https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator",
+              "properties": {
+                "localId": "https://data.vlaanderen.be/ns/generiek#lokaleIdentificator"
+              }
+            }
+          }
+        },
+        "targetAudience": {
+          "via": "http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/doelgroep",
+          "rdf_type": "http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/Doelgroep",
+          "properties": {
+            "minimumLeeftijd": "http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/minimumleeftijd",
+            "maximumLeeftijd": "http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/maximumleeftijd"
+          }
+        },
+        "recognitions": {
+          "via": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#heeftErkenning",
+          "rdf_type": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Erkenning",
+          "properties": {
+            "status": "http://www.w3.org/ns/adms#status",
+            "dateDocument": "http://data.europa.eu/eli/ontology#dateDocument",
+            "legalResource": "http://data.europa.eu/eli/ontology#hasLegalResource",
+            "validityPeriod": {
+              "via": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#geldigheidsperiode",
+              "rdf_type": "http://data.europa.eu/m8g/PeriodOfTime",
+              "properties": {
+                "startTime": "http://data.europa.eu/m8g/startTime",
+                "endTime": "http://data.europa.eu/m8g/endTime"
+              }
+            },
+            "awardedBy": "https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#toegekendDoor",
+            "association": "^https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#heeftErkenning"
+          }
+        },
+        "classification": {
+          "via": "http://www.w3.org/ns/org#classification",
+          "rdf_type": "http://www.w3.org/2004/02/skos/core#Concept",
+          "properties": {
+            "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
+            "notation": "http://www.w3.org/2004/02/skos/core#notation",
+            "modified": "http://purl.org/dc/terms/modified",
+            "conceptScheme": "http://www.w3.org/2004/02/skos/core#inScheme",
+            "broader": "http://www.w3.org/2004/02/skos/core#broader",
+            "top-concept-of": "http://www.w3.org/2004/02/skos/core#hasTopConcept"
+          }
+        }
+      },
+      "mappings": {
+        "properties": {
+          "recognitions.validityPeriod.startTime": {
+            "type": "date"
+          },
+          "recognitions.validityPeriod.endTime": {
+            "type": "date"
+          },
+          "name": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "date": {
+            "type": "date"
+          },
+          "createdOn": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "lastUpdateOn": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "primarySite.address.postcode": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "identifiers.structuredIdentifier.localId": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "status": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "status_id": {
+            "type": "text"
+          },
+          "targetAudience.minimumLeeftijd": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "targetAudience.maximumLeeftijd": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/scripts/increase-max-result-window.sh
+++ b/scripts/increase-max-result-window.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Get container ID for the 'elasticsearch' service
+CONTAINER_ID=$(docker compose ps -q elasticsearch)
+
+if [ -z "$CONTAINER_ID" ]; then
+  echo "Elasticsearch container not found. Is it running?"
+  exit 1
+fi
+
+MAX_RESULT_WINDOW=50000
+
+# Get list of all indices
+INDICES=$(docker exec "$CONTAINER_ID" curl -s http://localhost:9200/_cat/indices?h=index)
+
+if [ -z "$INDICES" ]; then
+  echo "No indices found or Elasticsearch is not reachable."
+  exit 1
+fi
+
+# Update max_result_window for each index (skip system indices)
+echo "Updating max_result_window for all user indices to $MAX_RESULT_WINDOW..."
+for index in $INDICES; do
+  if [[ "$index" == .* ]]; then
+    echo "Skipping system index: $index"
+    continue
+  fi
+
+  echo "Updating $index..."
+  docker exec "$CONTAINER_ID" curl -s -X PUT "http://localhost:9200/$index/_settings" \
+    -H 'Content-Type: application/json' \
+    -d "{
+      \"index\" : {
+        \"max_result_window\" : $MAX_RESULT_WINDOW
+      }
+    }"
+  echo
+done
+
+echo "Done."


### PR DESCRIPTION
cf deploy notes.

This increases the max_result_window

Ways to test. The changed setting can be viewed by getting the index from ES.

Also, running this python script will fail after 10k associations, but work after that.

```
import requests
import json

# Define the base URL and headers
base_url = 'http://localhost/search/associations/search'
headers = {
    'proxy_session': """YOUR-SESSION"""
  }


# Define the parameters for the request
params = {
    'page[size]': 50,
    'collapse_uuids': 't',
    'sort[createdOn.field]': 'desc'
}

# Initialize variables
all_data = []
page_number = 0
page_size = params['page[size]']

while True:
    # Update the page parameter
    params['page[number]'] = page_number

    # Make the request to the API
    # add logging to see the request
    print(f"Requesting page {page_number} with params: {params}")
    response = requests.get(base_url, headers=headers, params=params, cookies={'proxy_session': headers['proxy_session']})
    # Check if the request was successful
    if response.status_code == 200:
        data = response.json()

        print(data['count'])
        # Append the data from the current page to the list
        all_data.extend(data['data'])

        # Check if we have retrieved all the data
        if len(all_data) >= data['count']:
            break

        # Increment the page number
        page_number += 1
    else:
        print(f"Failed to retrieve data: {response.status_code}")
        print(response.text)
        break

# Print the total number of items retrieved
print(f"Total items retrieved: {len(all_data)}")
```