### PR TITLE
Write back to vereniginigsregister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,38 @@
 # Changelog
+
+## Unreleased - verenigingsregister api integration
+
+- patch address (for primary site) of an association
+
+### Deploy Notes
+
+To run with a developmemt version of the api-adapter
+
+Add to `docker-compose.override.yml` and replace the of DEV_KEY and DEV_CLIENT_ID and PATH_TO with the values from the development environment.
+
+```yaml
+verenigingen-api-adapter:
+  image: semtech/mu-javascript-template
+  environment:
+    NODE_ENV: 'development'
+    ENVIRONMENT: 'DEV'
+    AUD: 'https://authenticatie-ti.vlaanderen.be/op'
+    API_URL: 'https://iv.api.tni-vlaanderen.be/api/v1/organisaties/verenigingen/'
+    AUTHORIZATION_KEY: <DEV_KEY>
+    CLIENT_ID: <DEV_CLIENT_ID>
+    AUT_DOMAIN: 'authenticatie-ti.vlaanderen.be'
+    SCOPE: 'dv_magda_organisaties_verenigingen_verenigingen_v1_G dv_magda_organisaties_verenigingen_verenigingen_v1_A dv_magda_organisaties_verenigingen_verenigingen_v1_P'
+  ports:
+    - 8888:80
+    - 9229:9229
+  volumes:
+    - /<PATH_TO>/verenigingsregister-api-adapter-service/:/app/
+    - ./config/verenigingen-api-adapter:/config
+```
+
+
+
+
 ## 1.5.2 (2025-04-18)
 - bump frontend [v1.4.3]
 ## 1.5.1 (2025-04-17)
@@ -7,12 +41,14 @@
 ### Deploy Notes
 
 ```
+
 drc up -d frontend
+
 ```
 
 ## 1.5.0 (2025-04-17)
 - Fix bug related to duplicate values of some strings.
-  The consumer on initial sync wasn't properly handling multi-line strings. 
+  The consumer on initial sync wasn't properly handling multi-line strings.
   See [PR:delta-consumer](https://github.com/lblod/delta-consumer/pull/36)
   Bug reported [CLBV-1004]. Implies full flush.
 - Update of the data type: https://data.vlaanderen.be/ns/FeitelijkeVerenigingen#Vereniging
@@ -25,33 +61,44 @@ drc up -d frontend
 ### Deploy Notes
 Ensure backup first!
 ```
+
 drc down
+
 ```
 Ensure `docker-compose.override.yml` contains:
 ```
-  harvester-consumer:
-    environment:
-      DCR_LANDING_ZONE_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
-      DCR_REMAPPING_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
-      DCR_DISABLE_DELTA_INGEST: "true"
-      DCR_DISABLE_INITIAL_SYNC: "true"
+
+harvester-consumer:
+environment:
+DCR_LANDING_ZONE_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
+DCR_REMAPPING_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
+DCR_DISABLE_DELTA_INGEST: "true"
+DCR_DISABLE_INITIAL_SYNC: "true"
+
 ```
+
 ```
+
 drc up -d migrations
 drc up -d database harvester-consumer
 drc up -d
+
 ```
 Wait for the consumer to finish.
 If that looks okay; reset elastic.
 ```
+
 /bin/bash ./scripts/reset-elastic.sh
+
 ```
 Experienced readers might have noticed that we don't revert the consumer back to ingesting in the `database` to trigger constant updates of `mu-search` and other caches. There is a good reason for that: currently, we are facing a bug in both `mu-auth` and `sparql-parser` that occurs with strings exceeding the ASCII range.
 
 So, we'll have to temporarily revert to ingesting directly in Virtuoso and use a cron job running in the background. After everything is set up correctly, add a cron job on the server using `crontab -e`. Don't forget to update the paths depending on the environment you are in. Also respect the quircks of the cronfile.
 
 ```
-00 4 * * * cd /data/app-verenigingen-loket; ./scripts/reset-elastic.sh > /data/app-verenigingen-loket/reset-elastic.log 2>&1
+
+00 4 \* \* \* cd /data/app-verenigingen-loket; ./scripts/reset-elastic.sh > /data/app-verenigingen-loket/reset-elastic.log 2>&1
+
 ```
 That should be it.
 
@@ -61,7 +108,9 @@ That should be it.
 
 ### Deploy Notes
 ```
+
 drc up -d harvester-consumer op-consumer
+
 ```
 
 # 1.3.4 (2025-03-07)
@@ -97,8 +146,10 @@ Lots of fixes:
 
 ### Deploy instructions
 ```
+
 drc down;
 drc up -d
+
 ```
 
 ## 1.2.1 (2025-01-28)
@@ -106,13 +157,17 @@ drc up -d
 ### Deploy instructions
 #### production
 ```
+
 drc down;
 drc up -d --remove-orphans
+
 ```
 #### development/local
 ```
+
 git fetch origin
 git reset --hard origin/development
+
 ```
 
 ## 1.2.0 (2025-01-28)
@@ -121,15 +176,18 @@ git reset --hard origin/development
  - Ensure now only one graph, making accessible all verenigingen for all bestuurseenheden.
 ### Deploy instructions
 ```
+
 drc down
 rm -rf data
 drc up -d migrations # wait for successs
+
 ```
 On production only update `docker-compose.override.yml` to:
 ```
-  virtuoso:
-    volumes:
-      - ./config/virtuoso/virtuoso-production.ini:/data/virtuoso.ini
+
+virtuoso:
+volumes: - ./config/virtuoso/virtuoso-production.ini:/data/virtuoso.ini
+
 ```
 (Consider doing the same on QA if it helps)
 
@@ -138,77 +196,101 @@ Then start ingesting `OP` master data.
 Update `docker-compose.override.yml` to:
 
 ```
-  op-consumer:
-    environment:
-      DCR_SYNC_BASE_URL: "https://organisaties.abb.vlaanderen.be" # choose the correct endpoint
-      DCR_LANDING_ZONE_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
-      DCR_REMAPPING_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
-      DCR_DISABLE_DELTA_INGEST: "false"
-      DCR_DISABLE_INITIAL_SYNC: "false"
+
+op-consumer:
+environment:
+DCR_SYNC_BASE_URL: "https://organisaties.abb.vlaanderen.be" # choose the correct endpoint
+DCR_LANDING_ZONE_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
+DCR_REMAPPING_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
+DCR_DISABLE_DELTA_INGEST: "false"
+DCR_DISABLE_INITIAL_SYNC: "false"
+
 ```
 Then:
 ```
+
 drc up -d database op-consumer
+
 # Wait until success of the previous step
+
 drc up -d update-bestuurseenheid-mock-login
+
 # Wait until it boots, before running the next command. You can also wait the cron-job kicks in.
+
 drc exec update-bestuurseenheid-mock-login curl -X POST http://localhost/heal-mock-logins
+
 # Takes about 20 min with prod data
+
 ```
 Then, update `docker-compose.override.yml` to:
 ```
-  op-consumer:
-    environment:
-      DCR_SYNC_BASE_URL: "https://organisaties.abb.vlaanderen.be" # choose the correct endpoint
-      DCR_LANDING_ZONE_DATABASE: "database"
-      DCR_REMAPPING_DATABASE: "database"
-      DCR_DISABLE_DELTA_INGEST: "false"
-      DCR_DISABLE_INITIAL_SYNC: "false"
+
+op-consumer:
+environment:
+DCR_SYNC_BASE_URL: "https://organisaties.abb.vlaanderen.be" # choose the correct endpoint
+DCR_LANDING_ZONE_DATABASE: "database"
+DCR_REMAPPING_DATABASE: "database"
+DCR_DISABLE_DELTA_INGEST: "false"
+DCR_DISABLE_INITIAL_SYNC: "false"
+
 ```
+
 ```
+
 drc up -d op-consumer
+
 ```
 Then update the `verenigen-harvester` master data
 
 Update `docker-compose.override.yml` to:
 ```
-  harvester-consumer:
-    environment:
-      DCR_LANDING_ZONE_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
-      DCR_REMAPPING_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
-      DCR_DISABLE_DELTA_INGEST: "false"
-      DCR_DISABLE_INITIAL_SYNC: "false"
-      BATCH_SIZE: 2000
-      SLEEP_BETWEEN_BATCHES: 1
-      DCR_SYNC_BASE_URL: "https://harvester.verenigingen.lokaalbestuur.vlaanderen.be"
-      DCR_SYNC_LOGIN_ENDPOINT: "https://harvester.verenigingen.lokaalbestuur.vlaanderen.be/sync/verenigingen/login"
-      DCR_SECRET_KEY: "THE KEY"
+
+harvester-consumer:
+environment:
+DCR_LANDING_ZONE_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
+DCR_REMAPPING_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
+DCR_DISABLE_DELTA_INGEST: "false"
+DCR_DISABLE_INITIAL_SYNC: "false"
+BATCH_SIZE: 2000
+SLEEP_BETWEEN_BATCHES: 1
+DCR_SYNC_BASE_URL: "https://harvester.verenigingen.lokaalbestuur.vlaanderen.be"
+DCR_SYNC_LOGIN_ENDPOINT: "https://harvester.verenigingen.lokaalbestuur.vlaanderen.be/sync/verenigingen/login"
+DCR_SECRET_KEY: "THE KEY"
+
 ```
 
 ```
+
 drc up -d database harvester-consumer # wait until this message: delta-sync-queue: Remaining number of tasks 0
+
 ```
 Update `docker-compose.override.yml` to:
 ```
-  harvester-consumer:
-    environment:
-      DCR_LANDING_ZONE_DATABASE: "database" # Restore to database
-      DCR_REMAPPING_DATABASE: "database" # Restore to database
-      DCR_DISABLE_DELTA_INGEST: "false"
-      DCR_DISABLE_INITIAL_SYNC: "false"
-      BATCH_SIZE: 2000
-      SLEEP_BETWEEN_BATCHES: 1
-      DCR_SYNC_BASE_URL: "https://harvester.verenigingen.lokaalbestuur.vlaanderen.be"
-      DCR_SYNC_LOGIN_ENDPOINT: "https://harvester.verenigingen.lokaalbestuur.vlaanderen.be/sync/verenigingen/login"
-      DCR_SECRET_KEY: "THE KEY"
+
+harvester-consumer:
+environment:
+DCR_LANDING_ZONE_DATABASE: "database" # Restore to database
+DCR_REMAPPING_DATABASE: "database" # Restore to database
+DCR_DISABLE_DELTA_INGEST: "false"
+DCR_DISABLE_INITIAL_SYNC: "false"
+BATCH_SIZE: 2000
+SLEEP_BETWEEN_BATCHES: 1
+DCR_SYNC_BASE_URL: "https://harvester.verenigingen.lokaalbestuur.vlaanderen.be"
+DCR_SYNC_LOGIN_ENDPOINT: "https://harvester.verenigingen.lokaalbestuur.vlaanderen.be/sync/verenigingen/login"
+DCR_SECRET_KEY: "THE KEY"
+
 ```
 
 ```
+
 drc up -d
+
 ```
 Then kick the `mu-search` to do its thing:
 ```
+
 /bin/bash ./scripts/reset-elastic.sh
+
 ```
 ## 1.1.2 (2024-10-24)
 - [#19](https://github.com/lblod/app-verenigingen-loket/pull/19) [CLBV-930] Fix zwijndrecht's name ([@wolfderechter](https://github.com/wolfderechter))
@@ -220,3 +302,4 @@ Then kick the `mu-search` to do its thing:
 
 ## 1.1.0 (2024-08-12)
 - frontend [v1.1.0](https://github.com/lblod/frontend-verenigingen-loket/blob/master/CHANGELOG.md#v110-2024-08-06)
+```

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -9,7 +9,7 @@ defmodule Dispatcher do
     any: [ "*/*" ],
   ]
 
-  define_layers [ :api, :frontend, :not_found ]
+  define_layers [ :custom_api, :api, :frontend, :not_found ]
 
   @any %{}
   @json %{ accept: %{ json: true } }
@@ -55,12 +55,16 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/concepts/"
   end
 
-    match "/site-type/*path", %{ accept: [:json], layer: :api} do
+  match "/site-type/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/site-types/"
   end
 
   match "/sites/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/sites/"
+  end
+
+  patch "/addresses/*path", %{ accept: [:json], layer: :custom_api} do
+    Proxy.forward conn, path, "http://verenigingen-api-adapter/addresses/"
   end
 
   match "/addresses/*path", %{ accept: [:json], layer: :api} do


### PR DESCRIPTION
cf changelog for deployment notes.

First functionality:
- patch address for an association's primary site