### PR TITLE
[CLBV-586] Allow users to create and update contact points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Link recognitions to public organization [CLBV-1010] & [CLBV-972]
 - Restructure and strengthen dispatcher rules [DL-6515]
 - fix a pagination issue [CLBV-1024]
+- Allow users to edit contact details of associations [CLBV-586]
 
 ### Deploy notes
 

--- a/config/cl-authorization/config.lisp
+++ b/config/cl-authorization/config.lisp
@@ -50,6 +50,7 @@
   :org "http://www.w3.org/ns/org#"
   :organisatie "http://lblod.data.gift/vocabularies/organisatie/"
   :nfo "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#"
+  :schema "http://schema.org/"
   :ver "http://data.lblod.info/vocabularies/FeitelijkeVerenigingen/")
 
 ;;;;;;;;;;;;;;;;;
@@ -95,7 +96,10 @@
   ("m8g:PublicOrganisation" -> _)
   ("ver:AdHocOrganisatie" -> _)
   ("core:Concept" -> _)
-  ("core:ConceptScheme" -> _))
+  ("core:ConceptScheme" -> _)
+  ;; We add this here to make the edit page work without the custom service
+  ;; TODO: remove this once the microservice flow works as expected.
+  ("schema:ContactPoint" -> _))
 
 
 (define-graph organization ("http://mu.semte.ch/graphs/organizations/")

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -41,7 +41,9 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/ad-hoc-organizations/"
   end
 
-  get "/contact-points/*path", %{ accept: [:json], layer: :api } do
+  # TODO: we temporarily use match here so we can create and update records from the frontend
+  # This should be reverted again once we integrate the custom service.
+  match "/contact-points/*path", %{ accept: [:json], layer: :api } do
     Proxy.forward conn, path, "http://cache/contact-points/"
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   frontend:
-    image: lblod/frontend-verenigingen-loket:1.5.1
+    image: lblod/frontend-verenigingen-loket:feature-contact-details-edit-page
     links:
       - identifier:backend
     labels:


### PR DESCRIPTION
This adds the needed changes to make the contact details edit page in the frontend work. It's temporary code since this should go through the custom service #41 instead, but it allows us to test the frontend flows.

This PR doesn't include the address editing yet, I'll do that in a follow-up PR to make things easier to review.

Frontend part: https://github.com/lblod/frontend-verenigingen-loket/pull/84

**Test instructions**
- Start the app and open the bundled frontend
- Log in as a mock user
- Select a vereniging
- Go to the contact details page
- This should display a table of contact details and a correspondence address (if set)
- click the "Bewerk" button
- Try editing some contact details and saving