### PR TITLE
Review isPrimary feature

### DIFF
--- a/config/cl-authorization/config.lisp
+++ b/config/cl-authorization/config.lisp
@@ -80,7 +80,8 @@
   ("organisatie:BestuurseenheidClassificatieCode" -> _)
   ("organisatie:OrganisatieStatusCode" -> _)
   ("core:Concept" -> _)
-  ("core:ConceptScheme" -> _))
+  ("core:ConceptScheme" -> _)
+  ("org:Role" -> _))
 
 (define-graph verenigingen ("http://mu.semte.ch/graphs/organizations")
   ;; This is scoped by session_group and role when suppling access rights

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -119,6 +119,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/memberships/"
   end
 
+  get "/roles/*path", %{ accept: [:json], layer: :api } do
+    Proxy.forward conn, path, "http://cache/roles/"
+  end
+
   match "/recognitions/*path", %{ accept: [:json], layer: :api } do
     Proxy.forward conn, path, "http://cache/recognitions/"
   end

--- a/config/migrations/2025/20250828181103-roles-for-primary-memberships.graph
+++ b/config/migrations/2025/20250828181103-roles-for-primary-memberships.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2025/20250828181103-roles-for-primary-memberships.ttl
+++ b/config/migrations/2025/20250828181103-roles-for-primary-memberships.ttl
@@ -1,0 +1,17 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix concept: <http://lblod.data.gift/concepts/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+
+concept:75e74415-35cf-4da5-bac5-b72a1c137799
+  mu:uuid "75e74415-35cf-4da5-bac5-b72a1c137799" ;
+  rdf:type org:Role ;
+  skos:prefLabel "Primary" ;
+  skos:definition "This role indicates that an agent is the primary contact for their organisation." .
+
+concept:78451ac5-ec0b-469d-b918-0a8ef92a77b2
+  mu:uuid "78451ac5-ec0b-469d-b918-0a8ef92a77b2" ;
+  rdf:type org:Role ;
+  skos:prefLabel "Secondary" ;
+  skos:definition "This role indicates that an agent is not the primary contact for their organisation, but another contact point." .

--- a/config/resources/associations.lisp
+++ b/config/resources/associations.lisp
@@ -94,9 +94,17 @@
   :has-one `((person :via ,(s-prefix "org:member")
                      :as "person")
              (association :via ,(s-prefix "org:organization")
-                          :as "association"))
+                          :as "association")
+             (role :via ,(s-prefix "org:role")
+                   :as "role"))
   :on-path "memberships"
   :resource-base "http://data.lblod.info/id/identificatoren/")
+
+(define-resource role (concept)
+  :class (s-prefix "org:Role")
+  :on-path "roles"
+  :features '(include-uri)
+  :resource-base "http://lblod.data.gift/concepts/")
 
 (define-resource person ()
   :class (s-prefix "person:Person")

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -5,8 +5,8 @@
 (setf sparql:*experimental-no-application-graph-for-sudo-select-queries* t)
 (setf *cache-model-properties-p* t)
 
+(read-domain-file "concept.lisp")
 (read-domain-file "users.lisp")
 (read-domain-file "associations.lisp")
 (read-domain-file "extra.lisp")
 (read-domain-file "file.lisp")
-(read-domain-file "concept.lisp")


### PR DESCRIPTION
**[CLBV-1058]**

Marking a Representative as primary was done via its Person that can have multiple Contact Points that can have a type of Primary. This is in contrast with the data model from the Verenigingsregister, where "isPrimair" is a boolean property on the Representative itself. There is no direct mapping to RDF for this boolean, so in order to provide a proper solution, I opted to use for the `org:Role` model, since we already use that namespace for modelling Memberships to organisations.

Included in this PR are:

* A migration to add the Roles as concepts. Normally, `org:Role` is a subclass of `skos:Concept`.
* The dispatcher, and mu-auth rules for reading the related properties and resources.
* Resource definitions for the role on the Representative and the new Role resource.

Please test together with:
* Adapted scraper: https://github.com/lblod/harvesting-verenigingen-scraper-service/pull/19
* Inclusion in the export: https://github.com/lblod/app-verenigingen-loket-harvester/pull/18
* The adapted frontend: https://github.com/lblod/frontend-verenigingen-loket/pull/99