### PR TITLE
CLBV-1189: Association type changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+- Switch to verenigingenregister API v2 [CLBV-1189]
 - Frontend [v1.13.0](https://github.com/lblod/frontend-verenigingen-loket/blob/2aa838c54978a00069eb4919498073a860344179/CHANGELOG.md#v1130-2026-03-19), [v1.12.1](https://github.com/lblod/frontend-verenigingen-loket/blob/2d46fb0a0ce9f06df06ec92e1ded4f8125f9ce69/CHANGELOG.md#v1121-2026-03-10), [v1.12.0](https://github.com/lblod/frontend-verenigingen-loket/blob/a1f2a4a3bfd88f1ab886e3bd3ff17710d94ef830/CHANGELOG.md#v1120-2026-03-05)
 - Remove unused `verenigingen-lezer` read-only role [CLBV-1192]
 - Proxy service for Verenigingsregister API v1.5.0 [CLBV-1192]
@@ -7,8 +8,16 @@
 - Renamed client config directory to `verenigingsregister-client` for clarity because it's used for both the proxy and the download service and added some documentation on how to add new client configs. [CLBV-1183]
 
 ### Deploy notes
-  - the VR client key is used for both the proxy and the download service, so only one config needs to be added for both services. Add the client config to `/config/verenigingsregister-client/` (or move your existing config directory) and restart both services.
+  - Both app-verenigingen-loket-harvester and app-verenigingen-loket `feature/vzer` (TODO: replace with release tag) need to be deploted together and requires a full harvest to be done, so best to do this after business hours.
 
+    - check out app-verenigingen-loket
+    - run app-verenigingen-loket migrations
+    - `drc up -d` for app-verenigingen-loket-harvester
+    - trigger a full harvest (or wait for the scheduled nightly full harvest to run)
+    - `drc up -d` for app-verenigingen-loket
+
+
+  - the VR client key is used for both the proxy and the download service, so only one config needs to be added for both services. Add the client config to `/config/verenigingsregister-client/` (or move your existing config directory) and restart both services.
 ## 1.10.1
 - Frontend v1.11.1 [CLBV-1169]
 - Download service v4.1.0 [CLBV-1136]

--- a/config/migrations/2026/20260326120000-add-sub-nb-classification-codes.graph
+++ b/config/migrations/2026/20260326120000-add-sub-nb-classification-codes.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2026/20260326120000-add-sub-nb-classification-codes.ttl
+++ b/config/migrations/2026/20260326120000-add-sub-nb-classification-codes.ttl
@@ -1,0 +1,25 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+<http://data.vlaanderen.be/id/conceptscheme/VerenigingClassificatieCode/5c9ca00c-48ea-47f4-b5b3-e71ea83cde68>
+    a skos:Concept ;
+    mu:uuid "5c9ca00c-48ea-47f4-b5b3-e71ea83cde68" ;
+    skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/VerenigingClassificatieCode> ;
+    skos:notation "SUB" ;
+    skos:prefLabel "Subvereniging"@nl ;
+    skos:topConceptOf <http://data.vlaanderen.be/id/conceptscheme/VerenigingClassificatieCode> ;
+.
+
+<http://data.vlaanderen.be/id/conceptscheme/VerenigingClassificatieCode/f18372a8-f576-4233-b70c-84044f66b2f8>
+    a skos:Concept ;
+    mu:uuid "f18372a8-f576-4233-b70c-84044f66b2f8" ;
+    skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/VerenigingClassificatieCode> ;
+    skos:notation "NB" ;
+    skos:prefLabel "Niet Bepaald"@nl ;
+    skos:topConceptOf <http://data.vlaanderen.be/id/conceptscheme/VerenigingClassificatieCode> ;
+.
+
+<http://data.vlaanderen.be/id/conceptscheme/VerenigingClassificatieCode/f3c67343-57f8-587e-89a8-afe88ccsc8>
+    skos:hasTopConcept
+        <http://data.vlaanderen.be/id/conceptscheme/VerenigingClassificatieCode/5c9ca00c-48ea-47f4-b5b3-e71ea83cde68> ,
+        <http://data.vlaanderen.be/id/conceptscheme/VerenigingClassificatieCode/f18372a8-f576-4233-b70c-84044f66b2f8> .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,6 +164,7 @@ services:
   download:
     image: lblod/verenigingsloket-download-service:4.2.0
     environment:
+      API_VERSION: "v2"
       CRON_PATTERN_SPREADSHEET_JOB: "0 6 * * *"
       FEATURE_INCLUDE_REPRESENTATIVES: "false"
     volumes:
@@ -225,6 +226,7 @@ services:
   verenigingsregister-api-proxy:
     image: lblod/verenigingsregister-proxy-service:1.5.0
     environment:
+      API_VERSION: "v2"
       SCOPE: "dv_magda_organisaties_verenigingen_verenigingen_v1_G dv_magda_organisaties_verenigingen_verenigingen_v1_A dv_magda_organisaties_verenigingen_verenigingen_v1_P dv_magda_organisaties_verenigingen_verenigingen_v1_D"
       ENABLE_PROCESSING_AGREEMENT_CHECK: "false"
       ENABLE_REQUEST_REASON_CHECK: "false"


### PR DESCRIPTION
Both app-verenigingen-loket-harvester and app-verenigingen-loket `feature/vzer` (TODO: replace with release tag) need to be deployed together and requires a full harvest to be done, so best to do this after business hours.

    - check out app-verenigingen-loket
    - run app-verenigingen-loket migrations
    - `drc up -d` for app-verenigingen-loket-harvester
    - trigger a full harvest (or wait for the scheduled nightly full harvest to run)
    - `drc up -d` for app-verenigingen-loket