### PR TITLE
CLBV-1216: fix inconsistent load times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+- Fix indexing issue / inconsistent load times [CLBV-1216]
+
 ## 1.11.0 (2026-04-29)
 - Switch to verenigingenregister API v2 [CLBV-1189]
 - Frontend [v1.14.0](https://github.com/lblod/frontend-verenigingen-loket/blob/0b4b735d9061869618e5198dd3cd8bc8a4de5452/CHANGELOG.md#v1140-2026-04-20), [v1.13.0](https://github.com/lblod/frontend-verenigingen-loket/blob/2aa838c54978a00069eb4919498073a860344179/CHANGELOG.md#v1130-2026-03-19), [v1.12.1](https://github.com/lblod/frontend-verenigingen-loket/blob/2d46fb0a0ce9f06df06ec92e1ded4f8125f9ce69/CHANGELOG.md#v1121-2026-03-10), [v1.12.0](https://github.com/lblod/frontend-verenigingen-loket/blob/a1f2a4a3bfd88f1ab886e3bd3ff17710d94ef830/CHANGELOG.md#v1120-2026-03-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 - Fix indexing issue / inconsistent load times [CLBV-1216]
 
+### Deploy notes
+`drc restart search`
 ## 1.11.0 (2026-04-29)
 - Switch to verenigingenregister API v2 [CLBV-1189]
 - Frontend [v1.14.0](https://github.com/lblod/frontend-verenigingen-loket/blob/0b4b735d9061869618e5198dd3cd8bc8a4de5452/CHANGELOG.md#v1140-2026-04-20), [v1.13.0](https://github.com/lblod/frontend-verenigingen-loket/blob/2aa838c54978a00069eb4919498073a860344179/CHANGELOG.md#v1130-2026-03-19), [v1.12.1](https://github.com/lblod/frontend-verenigingen-loket/blob/2d46fb0a0ce9f06df06ec92e1ded4f8125f9ce69/CHANGELOG.md#v1121-2026-03-10), [v1.12.0](https://github.com/lblod/frontend-verenigingen-loket/blob/a1f2a4a3bfd88f1ab886e3bd3ff17710d94ef830/CHANGELOG.md#v1120-2026-03-05)

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -3,7 +3,10 @@
   "persist_indexes": true,
   "update_wait_interval_minutes": 1,
   "number_of_threads": 8,
-  "ignored_allowed_groups": [{ "name": "org", "variables": ["*"] }],
+  "ignored_allowed_groups": [
+    { "name": "org", "variables": ["*"] },
+    { "name": "account", "variables": ["*"] }
+  ],
   "eager_indexing_groups": [
     [
       {


### PR DESCRIPTION
ignores account variable which caused a re-index.

How to test:
- log in with different commune mock logins: page should load fast, no re-index in search logs
- search api call without valid search_session yields an empty result