### PR TITLE
bumped components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,47 @@
 ## Unreleased
 - Frontend [v1.15.0](https://github.com/lblod/frontend-verenigingen-loket/blob/master/CHANGELOG.md#v1150-2026-06-24)
 - Download service v4.4.0 [CLBV-1251]
+- Bump virtuoso to redpencil/virtuoso:1.4.0 [CLBV-1069]
+- Bump mu-search to stable v0.12.1 (was on feature branch) [CLBV-1214]
+- Bump acmidm-login to v0.13.0 [CLBV-1214]
+- Bump infrastructure services (mu-identifier, mu-dispatcher, sparql-parser, mu-migrations, mu-cache, mu-cl-resources, update-bestuurseenheid-mock-login, delta-consumer, mu-delta-notifier, mu-file-service, adressenregister-fuzzy-search) [CLBV-1214]
 
 ### Deploy notes
+
+All service bumps except virtuoso are backward-compatible drop-ins.
+
+**Virtuoso upgrade (7.2.5.1 → 7.2.9) - do with great care, take a backup first.** The engine
+version changes, so an in-place start is not supported: dump to nquads on the old image, then
+reload on the new one. Verified on QA copy (2.49M quads: dump ~30s,
+reload ~1min).
+
 ```
-drc up -d frontend download
+# 1. stop everything except virtuoso, so nothing writes during the dump
+docker compose ps --services --status running | grep -vx virtuoso | xargs docker compose stop
+
+# 2. dump nquads on the OLD virtuoso
+# dump_nquads only exists on dbs freshly initialised by the image, so load it first (idempotent)
+docker compose exec -T virtuoso sh -c 'isql-v < /dump_nquads_procedure.sql'
+docker compose exec -T virtuoso isql-v exec="dump_nquads ('dumps', 1, 1000000000, 1);"
+zcat data/db/dumps/*.nq.gz | wc -l    # keep this count for step 5
+
+# 3. stop the db, back up the old db files, stage the dump in toLoad
+docker compose stop virtuoso
+mkdir -p data/db-backup-7.2.5.1 data/db/toLoad
+mv data/db/virtuoso.db data/db/virtuoso.trx data/db/virtuoso.pxa data/db/virtuoso-temp.db \
+   data/db/virtuoso.log data/db/.dba_pwd_set data/db-backup-7.2.5.1/
+rm -f data/db/.data_loaded
+mv data/db/dumps/*.nq.gz data/db/toLoad/
+
+# 4. start the new virtuoso; the import is done once data/db/.data_loaded exists
+docker compose pull virtuoso && docker compose up -d virtuoso && docker compose logs -f virtuoso
+
+# 5. verify the count (>= step 2, surplus is virtuoso-internal graphs), then start the stack
+docker compose exec -T virtuoso isql-v exec="sparql select (count(*) as ?c) where { graph ?g { ?s ?p ?o } filter(?g != <http://www.openlinksw.com/schemas/virtrdf#>) };"
+docker compose up -d
 ```
+
+No search reindex needed. Once verified, remove `data/db-backup-7.2.5.1/` and `data/db/toLoad/*.nq.gz`.
 
 ## v1.11.1 (2026-05-19)
 

--- a/config/dispatcher/dispatcher-controle.ex
+++ b/config/dispatcher/dispatcher-controle.ex
@@ -15,125 +15,133 @@ defmodule Dispatcher do
   # BUSINESS RESOURCES
   ###############################################################
 
-  get "/organizations/*path", %{ accept: [:json], layer: :api } do
+  get "/organizations/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/organizations/"
   end
 
   # NOTE: only found in frontend model, never created as record
-  # post "/organizations/*path", %{ accept: [:json], layer: :api } do
+  # post "/organizations/*path", %{ accept: %{ json: true }, layer: :api } do
   #   Proxy.forward conn, path, "http://cache/organizations/"
   # end
 
-  get "/public-organizations/*path", %{ accept: [:json], layer: :api } do
+  get "/public-organizations/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/public-organizations/"
   end
 
   # NOTE: only found in frontend model, never created as record
-  # post "/public-organizations/*path", %{ accept: [:json], layer: :api } do
+  # post "/public-organizations/*path", %{ accept: %{ json: true }, layer: :api } do
   #   Proxy.forward conn, path, "http://cache/public-organizations/"
   # end
 
-  get "/ad-hoc-organizations/*path", %{ accept: [:json], layer: :api } do
+  get "/ad-hoc-organizations/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/ad-hoc-organizations/"
   end
 
-  post "/ad-hoc-organizations/*path", %{ accept: [:json], layer: :api } do
+  post "/ad-hoc-organizations/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/ad-hoc-organizations/"
   end
 
-  get "/contact-points/*path", %{ accept: [:json], layer: :api } do
+  get "/contact-points/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/contact-points/"
   end
 
   # NOTE: No request found in frontend
-  # match "/activities/*path", %{ accept: [:json], layer: :api } do
+  # match "/activities/*path", %{ accept: %{ json: true }, layer: :api } do
   #   Proxy.forward conn, path, "http://cache/activities/"
   # end
 
-  get "/change-events/*path", %{ accept: [:json], layer: :api } do
+  get "/change-events/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/change-events/"
   end
 
-  get "/concept-schemes/*path", %{ accept: [:json], layer: :api } do
+  get "/concept-schemes/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/concept-schemes/"
   end
 
-  get "/concepts/*path", %{ accept: [:json], layer: :api } do
+  get "/concepts/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/concepts/"
   end
 
-  get "/site-type/*path", %{ accept: [:json], layer: :api } do
+  get "/site-type/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/site-types/"
   end
 
-  get "/sites/*path", %{ accept: [:json], layer: :api } do
+  get "/sites/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/sites/"
   end
 
-  get "/addresses/*path", %{ accept: [:json], layer: :api } do
+  get "/addresses/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/addresses/"
   end
 
-  get "/administrative-unit-classification-codes/*path", %{ accept: [:json], layer: :api } do
+  get "/administrative-unit-classification-codes/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/administrative-unit-classification-codes/"
   end
 
-  get "/identifiers/*path", %{ accept: [:json], layer: :api } do
+  get "/identifiers/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/identifiers/"
   end
 
-  get "/structured-identifiers/*path", %{ accept: [:json], layer: :api } do
+  get "/structured-identifiers/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/structured-identifiers/"
   end
 
   # NOTE: resource used
-  get "/accounts", %{ accept: [:json], layer: :api } do
+  get "/accounts", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, [], "http://resource/accounts/"
   end
 
-  get "/administrative-units/*path", %{ accept: [:json], layer: :api } do
+  get "/administrative-units/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/administrative-units/"
   end
 
-  get "/governing-bodies/*path", %{ accept: [:json], layer: :api } do
+  get "/governing-bodies/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/governing-bodies/"
   end
 
-  get "/users/*path" do
+  get "/users/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/users/"
   end
 
-  get "/associations/*path", %{ accept: [:json], layer: :api } do
+  get "/associations/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/associations/"
   end
 
-  get "/organization-status-codes/*path", %{ accept: [:json], layer: :api } do
+  get "/organization-status-codes/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/organization-status-codes/"
   end
 
-  get "/persons/*path", %{ accept: [:json], layer: :api } do
+  get "/persons/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/persons/"
   end
 
-  get "/memberships/*path", %{ accept: [:json], layer: :api } do
+  get "/memberships/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/memberships/"
   end
 
-  match "/recognitions/*path", %{ accept: [:json], layer: :api } do
+  get "/roles/*path", %{ accept: %{ json: true }, layer: :api } do
+    Proxy.forward conn, path, "http://cache/roles/"
+  end
+
+  match "/recognitions/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/recognitions/"
   end
 
-  match "/periods/*path", %{ accept: [:json], layer: :api } do
+  match "/periods/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/periods/"
   end
 
-  get "/postal-codes/*path", %{ accept: [:any], layer: :api } do
+  get "/postal-codes/*path", %{ accept: %{ any: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/postal-codes/"
+  end
+
+  get "/countries/*path", %{ accept: %{ json: true }, layer: :api } do
+    Proxy.forward conn, path, "http://cache/countries/"
   end
 
   # NOTE: resource used
   # NOTE: no request found in frontend
-  # match "/groups/*path", %{ accept: [:json], layer: :api } do
+  # match "/groups/*path", %{ accept: %{ json: true }, layer: :api } do
   #   Proxy.forward conn, path, "http://resource/administrative-units/"
   # end
 
@@ -141,11 +149,11 @@ defmodule Dispatcher do
   # DOWNLOAD SERVICE
   ###############################################################
 
-  match "/verenigingen-downloads/*path", %{ accept: [:json], layer: :api } do
+  match "/verenigingen-downloads/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://download/sensitive-data-jobs/"
   end
 
-  get "/jobs/*path", %{ accept: [:json], layer: :api } do
+  get "/jobs/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://cache/jobs/"
   end
 
@@ -156,21 +164,21 @@ defmodule Dispatcher do
   # Resources
 
   # NOTE: resource used
-  get "/files/*path", %{layer: :api, accept: [ :json ]} do
+  get "/files/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://resource/files/"
   end
 
   # Service
 
-  post "/files/*path" do
+  post "/files/*path", %{ accept: %{ upload: true }, layer: :files } do
     Proxy.forward conn, path, "http://file/files/"
   end
 
-  get "/files/:id/download", %{ layer: :files } do
+  get "/files/:id/download", %{ accept: %{ any: true }, layer: :files } do
     Proxy.forward conn, [], "http://file/files/" <> id <> "/download"
   end
 
-  delete "/files/*path", %{ accept: [ :json ], layer: :files } do
+  delete "/files/*path", %{ accept: %{ json: true }, layer: :files } do
     Proxy.forward conn, path, "http://file/files/"
   end
 
@@ -178,7 +186,7 @@ defmodule Dispatcher do
   # ACCOUNTDETAILS
   ###############################################################
 
-  match "/accounts/*path", %{ accept: [:json], layer: :api } do
+  match "/accounts/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://accountdetail/accounts/"
   end
 
@@ -186,15 +194,23 @@ defmodule Dispatcher do
   # SEARCH
   ###############################################################
 
-  get "/search/*path", %{ accept: [:json], layer: :api } do
+  get "/search/*path", %{ accept: %{ json: true }, layer: :api } do
     Proxy.forward conn, path, "http://search/"
+  end
+
+  ##############################################################
+  # VERENIGINGSREGISTER API PROXY
+  ##############################################################
+
+  match "/verenigingen-proxy/*path", %{ accept: %{ json: true }, layer: :api } do
+    Proxy.forward conn, path, "http://verenigingsregister-api-proxy/verenigingen/"
   end
 
   ###############################################################
   # AUTHENTICATION
   ###############################################################
 
-  match "/mock/sessions/*path", %{ accept: [:any], layer: :api } do
+  match "/mock/sessions/*path", %{ accept: %{ any: true }, layer: :api } do
     Proxy.forward conn, path, "http://controle-login-proxied/sessions/"
   end
 
@@ -203,18 +219,26 @@ defmodule Dispatcher do
   end
 
   ###############################################################
+  # ADDRESS SEARCH
+  ###############################################################
+
+  get "/address-register/*path", %{ accept: %{ json: true }, layer: :api } do
+    Proxy.forward conn, path, "http://adressenregister/"
+  end
+
+  ###############################################################
   # FRONTEND
   ###############################################################
 
-  get "/assets/*path", %{ accept: [:any], layer: :frontend } do
+  get "/assets/*path", %{ accept: %{ any: true }, layer: :frontend } do
     Proxy.forward conn, path, "http://controle-frontend/assets/"
   end
 
-  get "/@appuniversum/*path", %{ accept: [:any], layer: :frontend } do
+  get "/@appuniversum/*path", %{ accept: %{ any: true }, layer: :frontend } do
     Proxy.forward conn, path, "http://controle-frontend/@appuniversum/"
   end
 
-  get "/*_path", %{ accept: [:html], layer: :frontend } do
+  get "/*_path", %{ accept: %{ html: true }, layer: :frontend } do
     Proxy.forward conn, [], "http://controle-frontend/index.html"
   end
 
@@ -227,7 +251,7 @@ defmodule Dispatcher do
   # NOTHING FOUND
   ###############################################################
 
-  match "/*_", %{ accept: [:any], layer: :not_found } do
+  match "/*_", %{ accept: %{ any: true }, layer: :not_found } do
     send_resp(conn, 404, "Route not found. See config/dispatcher.ex")
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     restart: always
     logging: *default-logging
   identifier:
-    image: semtech/mu-identifier:1.10.1
+    image: semtech/mu-identifier:1.11.0
     labels:
       - "logging=true"
     restart: always
@@ -30,7 +30,7 @@ services:
     restart: always
     logging: *default-logging
   dispatcher:
-    image: semtech/mu-dispatcher:2.1.0-beta.2
+    image: semtech/mu-dispatcher:2.1.1
     volumes:
       - ./config/dispatcher:/config
     labels:
@@ -46,7 +46,7 @@ services:
     restart: always
     logging: *default-logging
   database:
-    image: semtech/sparql-parser:0.0.14
+    image: semtech/sparql-parser:0.0.15
     volumes:
       - ./config/cl-authorization:/config
       - ./data/cl-authorization:/data
@@ -57,7 +57,7 @@ services:
     restart: always
     logging: *default-logging
   virtuoso:
-    image: tenforce/virtuoso:1.3.2-virtuoso7.2.5.1
+    image: redpencil/virtuoso:1.4.0
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"
@@ -69,7 +69,7 @@ services:
     restart: always
     logging: *default-logging
   migrations:
-    image: semtech/mu-migrations-service:0.6.0
+    image: semtech/mu-migrations-service:0.9.0
     links:
       - virtuoso:database
     environment:
@@ -81,7 +81,7 @@ services:
     restart: always
     logging: *default-logging
   cache:
-    image: semtech/mu-cache:2.0.1
+    image: semtech/mu-cache:2.1.0
     links:
       - resource:backend
     labels:
@@ -89,7 +89,7 @@ services:
     restart: always
     logging: *default-logging
   resource:
-    image: semtech/mu-cl-resources:1.25.0
+    image: semtech/mu-cl-resources:1.27.2
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
     volumes:
@@ -99,7 +99,7 @@ services:
     restart: always
     logging: *default-logging
   update-bestuurseenheid-mock-login:
-    image: lblod/update-bestuurseenheid-mock-login-service:0.4.0
+    image: lblod/update-bestuurseenheid-mock-login-service:0.6.0
     volumes:
       - ./config/mock-login:/config
     labels:
@@ -107,7 +107,7 @@ services:
     restart: always
     logging: *default-logging
   op-consumer:
-    image: lblod/delta-consumer:0.1.6
+    image: lblod/delta-consumer:0.1.7
     environment:
       DCR_SERVICE_NAME: "op-consumer"
       DCR_SYNC_BASE_URL: "https://organisaties.abb.lblod.info"
@@ -134,7 +134,7 @@ services:
       - "logging=true"
     logging: *default-logging
   harvester-consumer:
-    image: lblod/delta-consumer:0.1.6
+    image: lblod/delta-consumer:0.1.7
     environment:
       DCR_SERVICE_NAME: "harvester-consumer"
       DCR_SYNC_BASE_URL: "https://harvester.verenigingen-loket.lblod.info" # replace with link to Loket API
@@ -175,7 +175,7 @@ services:
     restart: always
     logging: *default-logging
   login:
-    image: lblod/acmidm-login-service:0.12.1.rc-2
+    image: lblod/acmidm-login-service:0.13.0
     environment:
       MU_APPLICATION_AUTH_USERID_CLAIM: "vo_id"
       MU_APPLICATION_AUTH_ROLE_CLAIM: "abb_loketverenigingenapp_rol_3d"
@@ -188,7 +188,7 @@ services:
     restart: always
     logging: *default-logging
   delta-notifier:
-    image: semtech/mu-delta-notifier:0.2.0
+    image: semtech/mu-delta-notifier:0.4.0
     volumes:
       - ./config/delta:/config
     labels:
@@ -196,7 +196,7 @@ services:
     restart: always
     logging: *default-logging
   search:
-    image: semtech/mu-search:feature-ignored_allowed_groups
+    image: semtech/mu-search:0.12.1
     volumes:
       - ./config/search:/config
     labels:
@@ -214,7 +214,7 @@ services:
     restart: always
     logging: *default-logging
   file:
-    image: semtech/mu-file-service:3.4.0
+    image: semtech/mu-file-service:3.5.0
     environment:
       MU_APPLICATION_FILE_STORAGE_PATH: recognitions
     volumes:
@@ -235,7 +235,7 @@ services:
     restart: always
     logging: *default-logging
   adressenregister:
-    image: lblod/adressenregister-fuzzy-search-service:0.8.0
+    image: lblod/adressenregister-fuzzy-search-service:0.8.2
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
Infra service bumps + virtuoso upgrade (frontend/download bumps are already on development).

- Bump virtuoso to redpencil/virtuoso:1.4.0, mu-search to stable 0.12.1 (was on a feature branch), acmidm-login 0.13.0, and the remaining infra services (identifier, dispatcher, sparql-parser, migrations, cache, resources, delta-consumer/-notifier, file, adressenregister, mock-login). All drop-ins except virtuoso.
- Virtuoso 7.2.5.1 → 7.2.9 is an engine change: dump to nquads on the old image, reload on the new. cf deploy notes. Verified end-to-end on a QA copy: 2.49M quads, business graphs identical after reload, no reindex needed. Don't `drc up -d` before the dump is done.
- dispatcher-controle.ex: sync `accept:` syntax with dispatcher.ex (goes with mu-dispatcher 2.1.1).
