### PR TITLE
[CLBV-1270] Link stad Antwerpen postcodes to their district werkingsgebied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 ## Unreleased
 - Bump verenigingsregister-proxy-service to v2.0.0 (drops obsolete VR-Initiator header and processing-agreement check) [CLBV-1148]
+- Link stad Antwerpen postcodes to their district werkingsgebied [CLBV-1270]
 
 ### Deploy notes
 
 ```
 drc up -d
+drc restart migrations
 ```
 
 ## v1.12.0 (2026-07-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 - Bump verenigingsregister-proxy-service to v2.0.0 (drops obsolete VR-Initiator header and processing-agreement check) [CLBV-1148]
 - Link stad Antwerpen postcodes to their district werkingsgebied [CLBV-1270]
+- Repair 2025-fusion postcode werkingsgebied links (26 postcodes, bpost 2025 source) [CLBV-1270]
 
 ### Deploy notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Bump verenigingsregister-proxy-service to v2.0.0 (drops obsolete VR-Initiator header and processing-agreement check) [CLBV-1148]
 - Link stad Antwerpen postcodes to their district werkingsgebied [CLBV-1270]
 - Repair 2025-fusion postcode werkingsgebied links (26 postcodes, bpost 2025 source) [CLBV-1270]
+- Bump frontend-verenigingen-loket to v1.16.0 (no-jurisdiction message covers province and district logins) [CLBV-1270]
+- Bump verenigingsloket-download-service to v4.5.0 (match associations to province and district werkingsgebied) [CLBV-1270]
+- Bump verenigingsregister-proxy-service to v2.1.0 (authorize province and district logins via the werkingsgebied hierarchy) [CLBV-1270]
 
 ### Deploy notes
 

--- a/config/migrations/2026/20260724112551-add-district-postcode-werkingsgebied.sparql
+++ b/config/migrations/2026/20260724112551-add-district-postcode-werkingsgebied.sparql
@@ -1,0 +1,37 @@
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?postInfo geo:sfWithin ?districtArea .
+  }
+}
+WHERE {
+  VALUES (?districtLabel ?postcode) {
+    ("Antwerpen" "2000")
+    ("Antwerpen" "2018")
+    ("Antwerpen" "2020")
+    ("Antwerpen" "2030")
+    ("Antwerpen" "2050")
+    ("Antwerpen" "2060")
+    ("Berchem" "2600")
+    ("Berendrecht-Zandvliet-Lillo" "2040")
+    ("Borgerhout" "2140")
+    ("Borsbeek" "2150")
+    ("Deurne" "2100")
+    ("Ekeren" "2180")
+    ("Hoboken" "2660")
+    ("Merksem" "2170")
+    ("Wilrijk" "2610")
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?district org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> ;
+      skos:prefLabel ?districtLabel ;
+      besluit:werkingsgebied ?districtArea .
+    ?postInfo a adres:Postinfo ;
+      adres:postcode ?postcode .
+  }
+}

--- a/config/migrations/2026/20260724125920-repair-2025-fusion-postcode-werkingsgebied.sparql
+++ b/config/migrations/2026/20260724125920-repair-2025-fusion-postcode-werkingsgebied.sparql
@@ -1,0 +1,84 @@
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?postInfo geo:sfWithin ?gemeenteArea .
+  }
+}
+WHERE {
+  VALUES (?gemeenteLabel ?postcode) {
+    ("Antwerpen" "2150")
+    ("Beveren-Kruibeke-Zwijndrecht" "2070")
+    ("Beveren-Kruibeke-Zwijndrecht" "9120")
+    ("Beveren-Kruibeke-Zwijndrecht" "9130")
+    ("Beveren-Kruibeke-Zwijndrecht" "9150")
+    ("Bilzen-Hoeselt" "3730")
+    ("Bilzen-Hoeselt" "3732")
+    ("Hasselt" "3720")
+    ("Hasselt" "3721")
+    ("Hasselt" "3722")
+    ("Hasselt" "3723")
+    ("Hasselt" "3724")
+    ("Lochristi" "9185")
+    ("Lokeren" "9180")
+    ("Merelbeke-Melle" "9090")
+    ("Merelbeke-Melle" "9820")
+    ("Nazareth-De Pinte" "9810")
+    ("Nazareth-De Pinte" "9840")
+    ("Pajottegem" "1540")
+    ("Pajottegem" "1541")
+    ("Pajottegem" "1570")
+    ("Pajottegem" "1755")
+    ("Tessenderlo-Ham" "3980")
+    ("Tielt" "8760")
+    ("Tongeren-Borgloon" "3840")
+    ("Wingene" "8755")
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?gemeente org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> ;
+      skos:prefLabel ?gemeenteLabel ;
+      regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+      besluit:werkingsgebied ?gemeenteArea .
+    ?postInfo a adres:Postinfo ;
+      adres:postcode ?postcode .
+  }
+}
+
+;
+
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?postInfo geo:sfWithin ?oldArea .
+  }
+}
+WHERE {
+  VALUES ?postcode {
+    "1540" "1541" "1570" "1755" "2070" "2150" "3720" "3721" "3722" "3723"
+    "3724" "3730" "3732" "3840" "3980" "8755" "8760" "9090" "9120" "9130"
+    "9150" "9180" "9185" "9810" "9820" "9840"
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?postInfo a adres:Postinfo ;
+      adres:postcode ?postcode ;
+      geo:sfWithin ?oldArea .
+    ?defunctGemeente org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> ;
+      besluit:werkingsgebied ?oldArea ;
+      regorg:orgStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> .
+    FILTER NOT EXISTS {
+      ?activeGemeente org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> ;
+        besluit:werkingsgebied ?oldArea ;
+        regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   frontend:
-    image: lblod/frontend-verenigingen-loket:1.15.0
+    image: lblod/frontend-verenigingen-loket:1.16.0
     links:
       - identifier:backend
     labels:
@@ -162,7 +162,7 @@ services:
       - "logging=true"
     logging: *default-logging
   download:
-    image: lblod/verenigingsloket-download-service:4.4.0
+    image: lblod/verenigingsloket-download-service:4.5.0
     environment:
       API_VERSION: "v2"
       CRON_PATTERN_SPREADSHEET_JOB: "0 6 * * *"
@@ -224,7 +224,7 @@ services:
     restart: always
     logging: *default-logging
   verenigingsregister-api-proxy:
-    image: lblod/verenigingsregister-proxy-service:2.0.0
+    image: lblod/verenigingsregister-proxy-service:2.1.0
     environment:
       API_VERSION: "v2"
       SCOPE: "dv_magda_organisaties_verenigingen_verenigingen_v1_G dv_magda_organisaties_verenigingen_verenigingen_v1_A dv_magda_organisaties_verenigingen_verenigingen_v1_P dv_magda_organisaties_verenigingen_verenigingen_v1_D"


### PR DESCRIPTION
Adds a migration seeding `Postinfo geo:sfWithin <district werkingsgebied>` edges for the 15 stad Antwerpen postcodes, one per district — including Borsbeek (2150), a district since the 2025 fusion. With these edges, district logins in lblod/verenigingsregister-proxy-service#12 and lblod/verenigingsloket-download-service#23 (and even the currently deployed single-hop query versions) are scoped to their own district instead of matching nothing.

**Validated against PRD data:** the INSERT's WHERE matches exactly 15 (district, postcode) pairs; resulting reach per district: Antwerpen 820, Deurne 306, Borgerhout 225, Berchem 196, Merksem 189, Wilrijk 172, Hoboken 150, Ekeren 131, Berendrecht-Zandvliet-Lillo 73, Borsbeek 41 associations. The migration is idempotent (plain INSERT-WHERE) and safe in any deploy order relative to the service releases.

**Second migration — 2025-fusion postcode repair:** the 2024 postcode seed predates the 2025 fusies: 26 postcodes still pointed only at the werkingsgebied of a defunct gemeente, leaving 1,762 associations invisible to their fused gemeente/stad login (Beveren-Kruibeke-Zwijndrecht, Merelbeke-Melle, Nazareth-De Pinte and Pajottegem saw nothing at all). Adds `Postinfo geo:sfWithin` edges to the active successor's werkingsgebied for those 26 postcodes, with the mapping sourced from the official bpost 2025 postcode list (dry-run on PRD: exactly 26 unambiguous pairs; the other 493 seeded postcodes match bpost exactly, and Flemish coverage is complete in both directions). The obsolete edges to the defunct gemeenten are dropped in the same migration (guarded so only areas held exclusively by Niet Actief gemeenten are touched — district and successor edges are unaffected). This also moves postcode 2070 (former Zwijndrecht) from provincie Antwerpen to Oost-Vlaanderen, matching the province change of that fusion — verified: Beveren-Kruibeke-Zwijndrecht's werkingsgebied sits `sfWithin` Oost-Vlaanderen, and today 2070 is (wrongly) reachable by provincie Antwerpen only. Also effective with the currently deployed service versions, any deploy order.
